### PR TITLE
feat(key-pair-resource): add option to generate rsa key

### DIFF
--- a/docs/resources/key_pair.md
+++ b/docs/resources/key_pair.md
@@ -44,7 +44,7 @@ resource "gpg_key_pair" "this" {
 
 ### Optional
 
-- `kind` (String) Kind of key
+- `kind` (String) Kind of key - Defaults to ECC
 
 ### Read-Only
 

--- a/docs/resources/key_pair.md
+++ b/docs/resources/key_pair.md
@@ -42,6 +42,10 @@ resource "gpg_key_pair" "this" {
 - `identities` (Attributes List) List of identities for the GPG key pair. Due to limitations in the underlying library only one identity is supported at the moment. (see [below for nested schema](#nestedatt--identities))
 - `passphrase` (String, Sensitive) Passphrase for locking the private key.
 
+### Optional
+
+- `kind` (String) Kind of key
+
 ### Read-Only
 
 - `fingerprint` (String) Fingerprint of the public key.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.3
 	github.com/ProtonMail/gopenpgp/v3 v3.1.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
-	github.com/hashicorp/terraform-plugin-framework v1.12.0
+	github.com/hashicorp/terraform-plugin-framework v1.13.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
 	github.com/hashicorp/terraform-plugin-go v0.25.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,10 @@ github.com/hashicorp/terraform-json v0.23.0 h1:sniCkExU4iKtTADReHzACkk8fnpQXrdD2
 github.com/hashicorp/terraform-json v0.23.0/go.mod h1:MHdXbBAbSg0GvzuWazEGKAn/cyNfIB7mN6y7KJN6y2c=
 github.com/hashicorp/terraform-plugin-docs v0.20.1 h1:Fq7E/HrU8kuZu3hNliZGwloFWSYfWEOWnylFhYQIoys=
 github.com/hashicorp/terraform-plugin-docs v0.20.1/go.mod h1:Yz6HoK7/EgzSrHPB9J/lWFzwl9/xep2OPnc5jaJDV90=
-github.com/hashicorp/terraform-plugin-framework v1.12.0 h1:7HKaueHPaikX5/7cbC1r9d1m12iYHY+FlNZEGxQ42CQ=
-github.com/hashicorp/terraform-plugin-framework v1.12.0/go.mod h1:N/IOQ2uYjW60Jp39Cp3mw7I/OpC/GfZ0385R0YibmkE=
+github.com/hashicorp/terraform-plugin-framework v1.13.0 h1:8OTG4+oZUfKgnfTdPTJwZ532Bh2BobF4H+yBiYJ/scw=
+github.com/hashicorp/terraform-plugin-framework v1.13.0/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
+github.com/hashicorp/terraform-plugin-framework-validators v0.16.0 h1:O9QqGoYDzQT7lwTXUsZEtgabeWW96zUBh47Smn2lkFA=
+github.com/hashicorp/terraform-plugin-framework-validators v0.16.0/go.mod h1:Bh89/hNmqsEWug4/XWKYBwtnw3tbz5BAy1L1OgvbIaY=
 github.com/hashicorp/terraform-plugin-go v0.25.0 h1:oi13cx7xXA6QciMcpcFi/rwA974rdTxjqEhXJjbAyks=
 github.com/hashicorp/terraform-plugin-go v0.25.0/go.mod h1:+SYagMYadJP86Kvn+TGeV+ofr/R3g4/If0O5sO96MVw=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/provider/key_pair_resource.go
+++ b/internal/provider/key_pair_resource.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"unsafe"
-
 	"github.com/ProtonMail/gopenpgp/v3/constants"
 	gpgcrypto "github.com/ProtonMail/gopenpgp/v3/crypto"
 	"github.com/ProtonMail/gopenpgp/v3/profile"
@@ -202,7 +200,7 @@ func (g KeyPairResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 	defer key.ClearPrivateParams()
 
-	key, err = pgp.LockKey(key, unsafe.Slice(unsafe.StringData(data.Passphrase.ValueString()), len(data.Passphrase.ValueString())))
+	key, err = pgp.LockKey(key, []byte(data.Passphrase.ValueString()))
 	if err != nil {
 		resp.Diagnostics.AddError("GPG key pair generation failed", fmt.Sprintf("LockKey failed with error: %s", err))
 		return

--- a/internal/provider/key_pair_resource.go
+++ b/internal/provider/key_pair_resource.go
@@ -72,7 +72,7 @@ func (g KeyPairResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"kind": schema.StringAttribute{
-				Description: "Kind of key",
+				Description: "Kind of key - Defaults to ECC",
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("default"),

--- a/internal/provider/key_pair_resource.go
+++ b/internal/provider/key_pair_resource.go
@@ -2,21 +2,23 @@ package provider
 
 import (
 	"context"
-	"crypto"
 	"encoding/hex"
 	"fmt"
-	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"unsafe"
+
 	"github.com/ProtonMail/gopenpgp/v3/constants"
 	gpgcrypto "github.com/ProtonMail/gopenpgp/v3/crypto"
 	"github.com/ProtonMail/gopenpgp/v3/profile"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"unsafe"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -69,6 +71,15 @@ func (g KeyPairResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				MarkdownDescription: "ID of the key pair in hex format.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"kind": schema.StringAttribute{
+				Description: "Kind of key",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("default"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("default", "rsa"),
 				},
 			},
 			"identities": schema.ListNestedAttribute{
@@ -155,6 +166,17 @@ func (g KeyPairResource) ValidateConfig(ctx context.Context, req resource.Valida
 	}
 }
 
+func (g KeyPairResource) getPGPProfile(kind string) *profile.Custom {
+	switch kind {
+	case "default":
+		return profile.Default()
+	case "rsa":
+		return profile.RFC4880()
+	default:
+		panic("unknown pgp key kind provided")
+	}
+}
+
 func (g KeyPairResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data keyPairModelV1
 
@@ -165,7 +187,7 @@ func (g KeyPairResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	var pgp = gpgcrypto.PGPWithProfile(GnuPG())
+	var pgp = gpgcrypto.PGPWithProfile(g.getPGPProfile(data.Kind.ValueString()))
 
 	builder := pgp.KeyGeneration()
 	for _, identity := range data.Identities {
@@ -245,6 +267,7 @@ func (g KeyPairResource) Delete(ctx context.Context, req resource.DeleteRequest,
 type keyPairModelV1 struct {
 	Id            types.String      `tfsdk:"id"`
 	Identities    []identityModelV1 `tfsdk:"identities"`
+	Kind		  types.String		`tfsdk:"kind"`
 	Passphrase    types.String      `tfsdk:"passphrase"`
 	Fingerprint   types.String      `tfsdk:"fingerprint"`
 	PrivateKey    types.String      `tfsdk:"private_key"`
@@ -255,20 +278,4 @@ type keyPairModelV1 struct {
 type identityModelV1 struct {
 	Name  types.String `tfsdk:"name"`
 	Email types.String `tfsdk:"email"`
-}
-
-// GnuPG returns a custom profile that conforms with modern algorithms available in GnuPG >=2.1.
-func GnuPG() *profile.Custom {
-	setKeyAlgorithm := func(cfg *packet.Config, securityLevel int8) {
-		cfg.Algorithm = packet.PubKeyAlgoEdDSA
-		cfg.Curve = packet.Curve25519
-		cfg.DefaultHash = crypto.SHA512
-	}
-	return &profile.Custom{
-		SetKeyAlgorithm:      setKeyAlgorithm,
-		Hash:                 crypto.SHA512,
-		CipherEncryption:     packet.CipherAES256,
-		CipherKeyEncryption:  packet.CipherAES256,
-		CompressionAlgorithm: packet.CompressionZLIB,
-	}
 }

--- a/internal/provider/key_resource.go
+++ b/internal/provider/key_resource.go
@@ -116,7 +116,7 @@ func keySchema() *schema.Schema {
 }
 
 func (g KeyResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data keyPairModelV1
+	var data keyModelV1
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
@@ -135,7 +135,7 @@ func (g KeyResource) ValidateConfig(ctx context.Context, req resource.ValidateCo
 }
 
 func (g KeyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data keyPairModelV1
+	var data keyModelV1
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -206,7 +206,7 @@ func (g KeyResource) Read(ctx context.Context, req resource.ReadRequest, resp *r
 
 // Update ensures the plan value is copied to the state to complete the update.
 func (g KeyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var model keyPairModelV1
+	var model keyModelV1
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
 
@@ -219,4 +219,20 @@ func (g KeyResource) Update(ctx context.Context, req resource.UpdateRequest, res
 
 func (g KeyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Nothing to do here.
+}
+
+type keyModelV1 struct {
+	Id            types.String      `tfsdk:"id"`
+	Identities    []keyIdentityModelV1 `tfsdk:"identities"`
+	Passphrase    types.String      `tfsdk:"passphrase"`
+	Fingerprint   types.String      `tfsdk:"fingerprint"`
+	PrivateKey    types.String      `tfsdk:"private_key"`
+	PrivateKeyHex types.String      `tfsdk:"private_key_hex"`
+	PublicKey     types.String      `tfsdk:"public_key"`
+	PublicKeyHex  types.String      `tfsdk:"public_key_hex"`
+}
+
+type keyIdentityModelV1 struct {
+	Name  types.String `tfsdk:"name"`
+	Email types.String `tfsdk:"email"`
 }

--- a/internal/provider/key_resource.go
+++ b/internal/provider/key_resource.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"unsafe"
+
 	"github.com/ProtonMail/gopenpgp/v3/constants"
 	gpgcrypto "github.com/ProtonMail/gopenpgp/v3/crypto"
+	"github.com/ProtonMail/gopenpgp/v3/profile"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -13,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"unsafe"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -142,7 +144,7 @@ func (g KeyResource) Create(ctx context.Context, req resource.CreateRequest, res
 		return
 	}
 
-	var pgp = gpgcrypto.PGPWithProfile(GnuPG())
+	var pgp = gpgcrypto.PGPWithProfile(profile.Default())
 
 	builder := pgp.KeyGeneration()
 	for _, identity := range data.Identities {


### PR DESCRIPTION
Add the option to generate a RSA key instead of ECC.

## Motivation

Terraform currently only allows RSA PGP keys for providers (as seen [here](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-release-publish#generate-gpg-signing-key))